### PR TITLE
Optionally get access_key and secret_key from environmental vars

### DIFF
--- a/LAMP/__init__.py
+++ b/LAMP/__init__.py
@@ -75,10 +75,12 @@ Sensor = SensorEventApi()
 SensorSpec = SensorEventApi()
 SensorEvent = SensorEventApi()
 
-def connect(access_key=None, secret_key=None, server_address="api.lamp.digital"):
+def connect(access_key=None, secret_key=None, server_address=None):
 	if access_key is None and secret_key is None:
 		access_key = os.getenv('LAMP_ACCESS_KEY')
 		secret_key = os.getenv('LAMP_SECRET_KEY')
+    if server_address is None:  # let arg override environmental var
+        server_address = os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital')
 	if access_key is None or secret_key is None:
 		raise TypeError("connect() requires 2 positional arguments: 'access_key' and 'secret_key', unless environmental variables 'LAMP_ACCESS_KEY' and 'LAMP_SECRET_KEY' are provided")
 

--- a/LAMP/__init__.py
+++ b/LAMP/__init__.py
@@ -11,6 +11,7 @@
 
 
 from __future__ import absolute_import
+import os
 
 __version__ = "develop"
 
@@ -74,7 +75,13 @@ Sensor = SensorEventApi()
 SensorSpec = SensorEventApi()
 SensorEvent = SensorEventApi()
 
-def connect(access_key, secret_key, server_address="api.lamp.digital"):
+def connect(access_key=None, secret_key=None, server_address="api.lamp.digital"):
+	if access_key is None and secret_key is None:
+		access_key = os.getenv('LAMP_ACCESS_KEY')
+		secret_key = os.getenv('LAMP_SECRET_KEY')
+	if access_key is None or secret_key is None:
+		raise TypeError("connect() requires 2 positional arguments: 'access_key' and 'secret_key', unless environmental variables 'LAMP_ACCESS_KEY' and 'LAMP_SECRET_KEY' are provided")
+
 	client = ApiClient(Configuration(host=f"https://{server_address}", username=access_key, password=secret_key))
 
 	global API

--- a/LAMP/__init__.py
+++ b/LAMP/__init__.py
@@ -79,8 +79,8 @@ def connect(access_key=None, secret_key=None, server_address=None):
 	if access_key is None and secret_key is None:
 		access_key = os.getenv('LAMP_ACCESS_KEY')
 		secret_key = os.getenv('LAMP_SECRET_KEY')
-    if server_address is None:  # let arg override environmental var
-        server_address = os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital')
+	if server_address is None:  # let arg override environmental var
+		server_address = os.getenv('LAMP_SERVER_ADDRESS', 'api.lamp.digital')
 	if access_key is None or secret_key is None:
 		raise TypeError("connect() requires 2 positional arguments: 'access_key' and 'secret_key', unless environmental variables 'LAMP_ACCESS_KEY' and 'LAMP_SECRET_KEY' are provided")
 


### PR DESCRIPTION
This could make it easier to connect without having to manually specify that we want to get our credentials from environmental vars